### PR TITLE
Fix deprecated syntax for compability with newer Ansible versions

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,3 +1,3 @@
 # file: webserver/handlers/main.yml
 ---
-- include: apache.yml
+- import_tasks: apache.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -26,7 +26,7 @@
     OPENSSL_CONF: "{{ role_path }}/files/openssl.cnf"
   become: False
 
-- include: generate_ca_and_sign.yml
+- include_tasks: generate_ca_and_sign.yml
   when: ssl_certificate_self_signed == True
 
 # certificate installation tasks


### PR DESCRIPTION
Changes include in handler to import_tasks (static) and in the tasks main.yml to include_tasks (dynamic). This is done as include is deprecated in newer ansible versions. include_tasks and import_tasks still work in older ansible-core versions such as 2.11.12.